### PR TITLE
Rails 4.1.8 fix quote_value call

### DIFF
--- a/lib/partitioned/by_time_field.rb
+++ b/lib/partitioned/by_time_field.rb
@@ -66,7 +66,7 @@ module Partitioned
       }
       partition.check_constraint lambda { |model, time_field|
         date = model.partition_normalize_key_value(time_field)
-        return "#{model.partition_time_field} >= #{quote_value(date)} AND #{model.partition_time_field} < #{quote_value(date + model.partition_table_size)}"
+        return "#{model.partition_time_field} >= #{quote_value(date, nil)} AND #{model.partition_time_field} < #{quote_value(date + model.partition_table_size, nil)}"
       }
     end
   end

--- a/lib/partitioned/version.rb
+++ b/lib/partitioned/version.rb
@@ -1,4 +1,4 @@
 module Partitioned
   # the current version of this gem
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
https://thinkneardev.atlassian.net/browse/GARD-1459

the call to quote_value now requires two arguments as of Rails 4.1.8 (see http://apidock.com/rails/ActiveRecord/Base/quote_value), with the 2nd argument having to be explicitly "nil", (instead of a default).  

Need this before we can upgrade ventura to rails 4.1.8
